### PR TITLE
Move typename, resource, and const declarations inside of module syntax.

### DIFF
--- a/phases/ephemeral/witx/typenames.witx
+++ b/phases/ephemeral/witx/typenames.witx
@@ -5,6 +5,8 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
+(module $typenames
+
 ;;; An array size.
 ;;;
 ;;; Note: This is similar to `size_t` in POSIX.
@@ -706,4 +708,6 @@
     ;;; When type is `preopentype::dir`:
     $prestat_dir
   )
+)
+
 )

--- a/phases/ephemeral/witx/wasi_ephemeral_args.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_args.witx
@@ -3,9 +3,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use $errno $size from $typenames)
-
 (module $wasi_ephemeral_args
+  (use $errno $size from $typenames)
+
   ;;; Read command-line argument data.
   ;;; The size of the array should match that returned by `sizes_get`.
   ;;; Each argument is expected to be `\0` terminated.

--- a/phases/ephemeral/witx/wasi_ephemeral_clock.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_clock.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use $clockid $timestamp $errno from $typenames)
-
 (module $wasi_ephemeral_clock
+  (use $clockid $timestamp $errno from $typenames)
+
   ;;; Return the resolution of a clock.
   ;;; Implementations are required to provide a non-zero value for supported clocks. For unsupported clocks,
   ;;; return `errno::inval`.

--- a/phases/ephemeral/witx/wasi_ephemeral_environ.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_environ.witx
@@ -3,9 +3,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use $errno $size from $typenames)
-
 (module $wasi_ephemeral_environ
+  (use $errno $size from $typenames)
+
   ;;; Read environment variable data.
   ;;; The sizes of the buffers should match that returned by `sizes_get`.
   ;;; Key/value pairs are expected to be joined with `=`s, and terminated with `\0`s.

--- a/phases/ephemeral/witx/wasi_ephemeral_fd.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_fd.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use * from $typenames)
-
 (module $wasi_ephemeral_fd
+  (use * from $typenames)
+
   ;;; Provide file advisory information on a file descriptor.
   ;;; Note: This is similar to `posix_fadvise` in POSIX.
   (@interface func (export "advise")

--- a/phases/ephemeral/witx/wasi_ephemeral_path.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_path.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use * from $typenames)
-
 (module $wasi_ephemeral_path
+  (use * from $typenames)
+
   ;;; Create a directory.
   ;;; Note: This is similar to `mkdirat` in POSIX.
   (@interface func (export "create_directory")

--- a/phases/ephemeral/witx/wasi_ephemeral_poll.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_poll.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use $event $subscription $size $errno from $typenames)
-
 (module $wasi_ephemeral_poll
+  (use $event $subscription $size $errno from $typenames)
+
   ;;; Concurrently poll for the occurrence of a set of events.
   ;;;
   ;;; If `nsubscriptions` is 0, returns `errno::inval`.

--- a/phases/ephemeral/witx/wasi_ephemeral_proc.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_proc.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use $exitcode from $typenames)
-
 (module $wasi_ephemeral_proc
+  (use $exitcode from $typenames)
+
   ;;; Terminate the process normally. An exit code of `$exitcode::success`
   ;;; reports successful completion of the program. An exit code of
   ;;; `$exitcode::failure` or any other value less than 126 reports a

--- a/phases/ephemeral/witx/wasi_ephemeral_random.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_random.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use $errno $size from $typenames)
-
 (module $wasi_ephemeral_random
+  (use $errno $size from $typenames)
+
   ;;; Write high-quality random data into a buffer.
   ;;; This function blocks when the implementation is unable to immediately
   ;;; provide sufficient high-quality random data.

--- a/phases/ephemeral/witx/wasi_ephemeral_sched.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_sched.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use $errno from $typenames)
-
 (module $wasi_ephemeral_sched
+  (use $errno from $typenames)
+
   ;;; Temporarily yield execution of the calling thread.
   ;;; Note: This is similar to `yield` in POSIX.
   (@interface func (export "yield")

--- a/phases/ephemeral/witx/wasi_ephemeral_sock.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_sock.witx
@@ -5,9 +5,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use * from $typenames)
-
 (module $wasi_ephemeral_sock
+  (use * from $typenames)
+
   ;;; Receive a message from a socket.
   ;;; Note: This is similar to `recv` in POSIX, though it also supports reading
   ;;; the data into multiple buffers in the manner of `readv`.

--- a/phases/old/snapshot_0/witx/typenames.witx
+++ b/phases/old/snapshot_0/witx/typenames.witx
@@ -5,6 +5,8 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/main/docs/witx.md)
 ;; for an explanation of what that means.
 
+(module $typenames
+
 (typename $size u32)
 
 ;;; Non-negative file size or length of a region within a file.
@@ -744,4 +746,6 @@
   (union (@witx tag $preopentype)
     $prestat_dir
   )
+)
+
 )

--- a/phases/old/snapshot_0/witx/wasi_unstable.witx
+++ b/phases/old/snapshot_0/witx/wasi_unstable.witx
@@ -6,12 +6,12 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use * from $typenames)
-
 ;;; This API predated the convention of naming modules with a `wasi_unstable_`
 ;;; prefix and a version number. It is preserved here for compatibility, but
 ;;; we shouldn't follow this pattern in new APIs.
 (module $wasi_unstable
+  (use * from $typenames)
+
   ;;; Read command-line argument data.
   ;;; The size of the array should match that returned by `args_sizes_get`.
   ;;; Each argument is expected to be `\0` terminated.

--- a/phases/snapshot/witx/typenames.witx
+++ b/phases/snapshot/witx/typenames.witx
@@ -5,6 +5,8 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
+(module $typenames
+
 (typename $size u32)
 
 ;;; Non-negative file size or length of a region within a file.
@@ -747,3 +749,4 @@
   )
 )
 
+)

--- a/phases/snapshot/witx/wasi_snapshot_preview1.witx
+++ b/phases/snapshot/witx/wasi_snapshot_preview1.witx
@@ -6,9 +6,9 @@
 ;; This is a `witx` file. See [here](https://github.com/WebAssembly/WASI/tree/master/docs/witx.md)
 ;; for an explanation of what that means.
 
-(use * from $typenames)
-
 (module $wasi_snapshot_preview1
+  (use * from $typenames)
+
   ;;; Read command-line argument data.
   ;;; The size of the array should match that returned by `args_sizes_get`.
   ;;; Each argument is expected to be `\0` terminated.

--- a/tools/witx/cli/src/main.rs
+++ b/tools/witx/cli/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -56,9 +57,10 @@ pub fn main() {
             check,
             output,
         } => {
+            let mut universe = HashMap::new();
             let modules = input
                 .iter()
-                .map(|i| load_witx(i, "input", verbose))
+                .map(|i| load_witx(i, &mut universe, "input", verbose))
                 .collect::<Vec<_>>();
             let docs = witx::document(&modules);
             if check {

--- a/tools/witx/src/abi.rs
+++ b/tools/witx/src/abi.rs
@@ -248,43 +248,43 @@ def_instruction! {
         /// representation of `f64`.
         F64FromIf64 : [1] => [1],
 
-        /// Converts a native wasm `i32` to an interface type `s8`.
+        /// Converts a core wasm `i32` to an interface type `s8`.
         ///
         /// This will truncate the upper bits of the `i32`.
         S8FromI32 : [1] => [1],
-        /// Converts a native wasm `i32` to an interface type `u8`.
+        /// Converts a core wasm `i32` to an interface type `u8`.
         ///
         /// This will truncate the upper bits of the `i32`.
         U8FromI32 : [1] => [1],
-        /// Converts a native wasm `i32` to an interface type `s16`.
+        /// Converts a core wasm `i32` to an interface type `s16`.
         ///
         /// This will truncate the upper bits of the `i32`.
         S16FromI32 : [1] => [1],
-        /// Converts a native wasm `i32` to an interface type `u16`.
+        /// Converts a core wasm `i32` to an interface type `u16`.
         ///
         /// This will truncate the upper bits of the `i32`.
         U16FromI32 : [1] => [1],
-        /// Converts a native wasm `i32` to an interface type `s32`.
+        /// Converts a core wasm `i32` to an interface type `s32`.
         S32FromI32 : [1] => [1],
-        /// Converts a native wasm `i32` to an interface type `u32`.
+        /// Converts a core wasm `i32` to an interface type `u32`.
         U32FromI32 : [1] => [1],
-        /// Converts a native wasm `i64` to an interface type `s64`.
+        /// Converts a core wasm `i64` to an interface type `s64`.
         S64FromI64 : [1] => [1],
-        /// Converts a native wasm `i64` to an interface type `u64`.
+        /// Converts a core wasm `i64` to an interface type `u64`.
         U64FromI64 : [1] => [1],
-        /// Converts a native wasm `i32` to an interface type `char`.
+        /// Converts a core wasm `i32` to an interface type `char`.
         ///
         /// It's safe to assume that the `i32` is indeed a valid unicode code point.
         CharFromI32 : [1] => [1],
-        /// Converts a native wasm `f32` to an interface type `f32`.
+        /// Converts a core wasm `f32` to an interface type `f32`.
         If32FromF32 : [1] => [1],
-        /// Converts a native wasm `f64` to an interface type `f64`.
+        /// Converts a core wasm `f64` to an interface type `f64`.
         If64FromF64 : [1] => [1],
-        /// Converts a native wasm `i32` to a language-specific C `char`.
+        /// Converts a core wasm `i32` to a language-specific C `char`.
         ///
         /// This will truncate the upper bits of the `i32`.
         Char8FromI32 : [1] => [1],
-        /// Converts a native wasm `i32` to a language-specific `usize`.
+        /// Converts a core wasm `i32` to a language-specific `usize`.
         UsizeFromI32 : [1] => [1],
 
         // Handles
@@ -348,7 +348,7 @@ def_instruction! {
         /// question was defined.
         I32FromOwnedHandle { ty: &'a NamedType } : [1] => [1],
 
-        /// Converts a native wasm `i32` into an owned handle value.
+        /// Converts a core wasm `i32` into an owned handle value.
         ///
         /// This is the converse of `I32FromOwnedHandle` and is used in similar
         /// situations:
@@ -367,7 +367,7 @@ def_instruction! {
         /// just yet.
         HandleOwnedFromI32 { ty: &'a NamedType } : [1] => [1],
 
-        /// Converts a native wasm `i32` into a borrowedhandle value.
+        /// Converts a core wasm `i32` into a borrowedhandle value.
         ///
         /// This is the converse of `I32FromBorrowedHandle` and is used in similar
         /// situations:
@@ -520,13 +520,13 @@ def_instruction! {
             ty: &'a RecordDatatype,
             name: &'a NamedType,
         } : [1] => [1],
-        /// Converts a native wasm `i32` to a language-specific record-of-bools.
+        /// Converts a core wasm `i32` to a language-specific record-of-bools.
         BitflagsFromI32 {
             repr: IntRepr,
             ty: &'a RecordDatatype,
             name: &'a NamedType,
         } : [1] => [1],
-        /// Converts a native wasm `i64` to a language-specific record-of-bools.
+        /// Converts a core wasm `i64` to a language-specific record-of-bools.
         BitflagsFromI64 {
             repr: IntRepr,
             ty: &'a RecordDatatype,
@@ -619,9 +619,9 @@ def_instruction! {
         I32FromPointer : [1] => [1],
         /// Converts a language-specific pointer value to a wasm `i32`.
         I32FromConstPointer : [1] => [1],
-        /// Converts a native wasm `i32` to a language-specific pointer.
+        /// Converts a core wasm `i32` to a language-specific pointer.
         PointerFromI32 { ty: &'a TypeRef }: [1] => [1],
-        /// Converts a native wasm `i32` to a language-specific pointer.
+        /// Converts a core wasm `i32` to a language-specific pointer.
         ConstPointerFromI32 { ty: &'a TypeRef } : [1] => [1],
 
         /// This is a special instruction specifically for the original ABI of

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -229,11 +229,7 @@ impl<'a> Parse<'a> for TopLevelModule<'a> {
 
         let mut comments = parser.parse()?;
         loop {
-            if parser.peek2::<kw::r#use>()
-                || parser.peek2::<annotation::witx>()
-                || parser.peek2::<kw::typename>()
-                || parser.peek2::<kw::resource>()
-            {
+            if parser.peek2::<kw::r#use>() {
                 decls.push(Documented {
                     comments,
                     item: parser.parens(|p| p.parse())?,
@@ -249,10 +245,19 @@ impl<'a> Parse<'a> for TopLevelModule<'a> {
                 p.parse::<kw::module>()?;
                 module_name = p.parse()?;
                 while !p.is_empty() {
-                    functions.push(Documented {
-                        comments: parser.parse()?,
-                        item: p.parens(|p| p.parse())?,
-                    });
+                    if parser.peek2::<kw::typename>()
+                        || parser.peek2::<kw::resource>()
+                        || parser.peek2::<annotation::witx>() {
+                        decls.push(Documented {
+                            comments: parser.parse()?,
+                            item: parser.parens(|p| p.parse())?,
+                        });
+                    } else {
+                        functions.push(Documented {
+                            comments: parser.parse()?,
+                            item: p.parens(|p| p.parse())?,
+                        });
+                    }
                 }
                 Ok(())
             })?;

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -247,7 +247,8 @@ impl<'a> Parse<'a> for TopLevelModule<'a> {
                 while !p.is_empty() {
                     if parser.peek2::<kw::typename>()
                         || parser.peek2::<kw::resource>()
-                        || parser.peek2::<annotation::witx>() {
+                        || parser.peek2::<annotation::witx>()
+                    {
                         decls.push(Documented {
                             comments: parser.parse()?,
                             item: parser.parens(|p| p.parse())?,

--- a/tools/witx/src/parser.rs
+++ b/tools/witx/src/parser.rs
@@ -227,25 +227,17 @@ impl<'a> Parse<'a> for TopLevelModule<'a> {
         let mut functions = Vec::new();
         let mut module_name = None;
 
-        let mut comments = parser.parse()?;
-        loop {
-            if parser.peek2::<kw::r#use>() {
-                decls.push(Documented {
-                    comments,
-                    item: parser.parens(|p| p.parse())?,
-                });
-                comments = parser.parse()?;
-            } else {
-                break;
-            }
-        }
-
         if parser.peek2::<kw::module>() {
             parser.parens(|p| {
                 p.parse::<kw::module>()?;
                 module_name = p.parse()?;
                 while !p.is_empty() {
-                    if parser.peek2::<kw::typename>()
+                    if parser.peek2::<kw::r#use>() {
+                        decls.push(Documented {
+                            comments: parser.parse()?,
+                            item: parser.parens(|p| p.parse())?,
+                        });
+                    } else if parser.peek2::<kw::typename>()
                         || parser.peek2::<kw::resource>()
                         || parser.peek2::<annotation::witx>()
                     {

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -99,7 +99,7 @@ mod test {
     fn one_use() {
         parse_witx_with(
             "/a",
-            &MockFs::new(&[("/a", "(use $x from $b)"), ("/b.witx", "(typename $x u8)")]),
+            &MockFs::new(&[("/a", "(use $x from $b)"), ("/b.witx", "(module $x (typename $x u8))")]),
         )
         .unwrap();
     }
@@ -110,8 +110,8 @@ mod test {
             "/a",
             &MockFs::new(&[
                 ("/a", "(use $b_float $c_int from $b)"),
-                ("/b.witx", "(use $c_int from $c)\n(typename $b_float f64)"),
-                ("/c.witx", "(typename $c_int u32)"),
+                ("/b.witx", "(use $c_int from $c)\n(module $x (typename $b_float f64))"),
+                ("/c.witx", "(module $x (typename $c_int u32))"),
             ]),
         )
         .expect("parse");
@@ -136,13 +136,13 @@ mod test {
                 ("/a", "(use $b_char from $b)\n(use $c_char from $c)"),
                 (
                     "/b.witx",
-                    "(use $d_char from $d) (typename $b_char $d_char)",
+                    "(use $d_char from $d) (module $x (typename $b_char $d_char))",
                 ),
                 (
                     "/c.witx",
-                    "(use $d_char from $d) (typename $c_char $d_char)",
+                    "(use $d_char from $d) (module $x (typename $c_char $d_char))",
                 ),
-                ("/d.witx", "(typename $d_char u8)"),
+                ("/d.witx", "(module $x (typename $d_char u8))"),
             ]),
         )
         .expect("parse");

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -53,7 +53,7 @@ fn _parse(
     let mut validator = ModuleValidation::new(&input, name, path);
 
     if let Some(name) = doc.module_name {
-        if file_name != name.name() {
+        if file_name != "-" && file_name != name.name() {
             let location = validator.location(name.span());
             return Err(ValidationError::ModuleNameMismatch {
                 location,

--- a/tools/witx/src/toplevel.rs
+++ b/tools/witx/src/toplevel.rs
@@ -99,7 +99,10 @@ mod test {
     fn one_use() {
         parse_witx_with(
             "/a",
-            &MockFs::new(&[("/a", "(use $x from $b)"), ("/b.witx", "(module $x (typename $x u8))")]),
+            &MockFs::new(&[
+                ("/a", "(use $x from $b)"),
+                ("/b.witx", "(module $x (typename $x u8))"),
+            ]),
         )
         .unwrap();
     }
@@ -110,7 +113,10 @@ mod test {
             "/a",
             &MockFs::new(&[
                 ("/a", "(use $b_float $c_int from $b)"),
-                ("/b.witx", "(use $c_int from $c)\n(module $x (typename $b_float f64))"),
+                (
+                    "/b.witx",
+                    "(use $c_int from $c)\n(module $x (typename $b_float f64))",
+                ),
                 ("/c.witx", "(module $x (typename $c_int u32))"),
             ]),
         )

--- a/tools/witx/src/validate.rs
+++ b/tools/witx/src/validate.rs
@@ -60,6 +60,12 @@ pub enum ValidationError {
     },
     #[error("Variant has zero cases")]
     ZeroCaseVariant { location: Location },
+    #[error("Module name `{module_name}` doesn't match file name `{file_name}`")]
+    ModuleNameMismatch {
+        location: Location,
+        module_name: String,
+        file_name: String,
+    },
 }
 
 impl ValidationError {
@@ -76,7 +82,8 @@ impl ValidationError {
             | ZeroCaseVariant { location }
             | InvalidUnionField { location, .. }
             | InvalidUnionTag { location, .. }
-            | CyclicModule { location } => {
+            | CyclicModule { location }
+            | ModuleNameMismatch { location, .. } => {
                 format!("{}\n{}", location.highlight_source_with(witxio), &self)
             }
             NameAlreadyExists {
@@ -144,8 +151,8 @@ pub struct ModuleValidation<'a> {
 }
 
 impl<'a> ModuleValidation<'a> {
-    pub fn new(text: &'a str, path: &'a Path) -> Self {
-        let name = Id::new(path.file_stem().unwrap().to_str().unwrap());
+    pub fn new(text: &'a str, name: &'a str, path: &'a Path) -> Self {
+        let name = Id::new(name);
         let module_id = ModuleId(Rc::new(path.to_path_buf()));
         Self {
             module: Module::new(name, module_id),

--- a/tools/witx/tests/witxt.rs
+++ b/tools/witx/tests/witxt.rs
@@ -659,7 +659,14 @@ impl Witx<'_> {
 
         match &self.def {
             WitxDef::Inline(doc) => {
-                let mut validator = witx::ModuleValidation::new(contents, file);
+                if doc.module_name.is_none() {
+                    dbg!(file);
+                }
+                let module_name = doc
+                    .module_name
+                    .expect("inline modules should have a name")
+                    .name();
+                let mut validator = witx::ModuleValidation::new(contents, module_name, file);
                 for t in doc.decls.iter() {
                     match &t.item {
                         TopLevelSyntax::Decl(d) => validator

--- a/tools/witx/tests/witxt/abi-next.witxt
+++ b/tools/witx/tests/witxt/abi-next.witxt
@@ -76,9 +76,11 @@
 ;; handle argument
 (assert_abi
   (witx
-    (resource $y)
-    (typename $y (handle $y))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (resource $y)
+      (typename $y (handle $y))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm (param i32))
   (declared_import get-arg0 i32.from_borrowed_handle arg0 call.wasm return)
@@ -88,8 +90,10 @@
 ;; record arguments
 (assert_abi
   (witx
-    (typename $y (record))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (typename $y (record))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm)
   (declared_import get-arg0 record-lower arg0 call.wasm return)
@@ -98,8 +102,10 @@
 
 (assert_abi
   (witx
-    (typename $y (record (field $a u32)))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (typename $y (record (field $a u32)))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm (param i32))
   (declared_import
@@ -117,11 +123,13 @@
 )
 (assert_abi
   (witx
-    (typename $y (record
-      (field $a u32)
-      (field $b s64)
-    ))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (typename $y (record
+        (field $a u32)
+        (field $b s64)
+      ))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm (param i32 i64))
   (declared_import
@@ -142,14 +150,16 @@
 )
 (assert_abi
   (witx
-    (typename $empty (record))
-    (typename $tuple (tuple f64 u32))
-    (typename $y (record
-      (field $a u32)
-      (field $b $empty)
-      (field $c $tuple)
-    ))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (typename $empty (record))
+      (typename $tuple (tuple f64 u32))
+      (typename $y (record
+        (field $a u32)
+        (field $b $empty)
+        (field $c $tuple)
+      ))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm (param i32 f64 i32))
   (declared_import
@@ -179,8 +189,10 @@
 ;; variant arguments
 (assert_abi
   (witx
-    (typename $y (enum $a $b))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (typename $y (enum $a $b))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm (param i32))
   (declared_import
@@ -207,8 +219,10 @@
 
 (assert_abi
   (witx
-    (typename $y (union u32 f32))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (typename $y (union u32 f32))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm (param i32 i32))
   (declared_import
@@ -244,8 +258,10 @@
 
 (assert_abi
   (witx
-    (typename $y (variant (case $none) (case $some f64)))
-    (module $x (export "f" (func (param $p $y))))
+    (module $x
+      (typename $y (variant (case $none) (case $some f64)))
+      (export "f" (func (param $p $y)))
+    )
   )
   (wasm (param i32 f64))
   (declared_import
@@ -314,20 +330,22 @@
 ;; flavorful parameters
 (assert_abi
   (witx
-    (typename $a (union (list u8) f32))
-    (typename $b (tuple f64 bool))
-    (typename $c (record
-      (field $a $a)
-      (field $b $b)
-    ))
+    (module $x
+      (typename $a (union (list u8) f32))
+      (typename $b (tuple f64 bool))
+      (typename $c (record
+        (field $a $a)
+        (field $b $b)
+      ))
 
-    (typename $d (tuple f32 f64))
-    (typename $e (variant
-      (case $a)
-      (case $b $d)
-      (case $c)
-    ))
-    (module $x (export "f" (func
+      (typename $d (tuple f32 f64))
+      (typename $e (variant
+        (case $a)
+        (case $b $d)
+        (case $c)
+      ))
+
+      (export "f" (func
       (param $p1 $c)
       (param $p2 s32)
       (param $p3 $e)
@@ -515,9 +533,11 @@
 ;; handle result
 (assert_abi
   (witx
-    (resource $y)
-    (typename $y (handle $y))
-    (module $x (export "f" (func (result $p $y))))
+    (module $x
+      (resource $y)
+      (typename $y (handle $y))
+      (export "f" (func (result $p $y)))
+    )
   )
   (wasm (result i32))
   (declared_import call.wasm handle.owned_from_i32 ret0 return)
@@ -527,8 +547,10 @@
 ;; record results
 (assert_abi
   (witx
-    (typename $y (record))
-    (module $x (export "f" (func (result $p $y))))
+    (module $x
+      (typename $y (record))
+      (export "f" (func (result $p $y)))
+    )
   )
   (wasm)
   (declared_import call.wasm record-lift return)
@@ -536,8 +558,10 @@
 )
 (assert_abi
   (witx
-    (typename $y (record (field $a s32)))
-    (module $x (export "f" (func (result $p $y))))
+    (module $x
+      (typename $y (record (field $a s32)))
+      (export "f" (func (result $p $y)))
+    )
   )
   (wasm (result i32))
   (declared_import call.wasm s32.from_i32 ret0 record-lift return)
@@ -549,8 +573,10 @@
 )
 (assert_abi
   (witx
-    (typename $y (record (field $a s32) (field $b u32)))
-    (module $x (export "f" (func (result $p $y))))
+    (module $x
+      (typename $y (record (field $a s32) (field $b u32)))
+      (export "f" (func (result $p $y)))
+    )
   )
   (wasm (param i32))
   (declared_import
@@ -574,8 +600,10 @@
 ;; variant results
 (assert_abi
   (witx
-    (typename $y (enum $a $b))
-    (module $x (export "f" (func (result $p $y))))
+    (module $x
+      (typename $y (enum $a $b))
+      (export "f" (func (result $p $y)))
+    )
   )
   (wasm (result i32))
   (declared_import
@@ -600,8 +628,10 @@
 
 (assert_abi
   (witx
-    (typename $y (variant (case $a f32) (case $b)))
-    (module $x (export "f" (func (result $p $y))))
+    (module $x
+      (typename $y (variant (case $a f32) (case $b)))
+      (export "f" (func (result $p $y)))
+    )
   )
   (wasm (param i32))
   (declared_import
@@ -752,8 +782,10 @@
 )
 (assert_abi
   (witx
-    (typename $a (record (field $x bool) (field $y (list u8))))
-    (module $x (export "f" (func (param $a (list $a)))))
+    (module $x
+      (typename $a (record (field $x bool) (field $y (list u8))))
+      (export "f" (func (param $a (list $a))))
+    )
   )
   (wasm (param i32 i32))
   (declared_import
@@ -804,8 +836,10 @@
 ;; bitflags
 (assert_abi
   (witx
-    (typename $a (flags $a $b))
-    (module $x (export "f" (func (param $a $a) (result $b $a))))
+    (module $x
+      (typename $a (flags $a $b))
+      (export "f" (func (param $a $a) (result $b $a)))
+    )
   )
   (wasm (param i32) (result i32))
   (declared_import
@@ -825,24 +859,28 @@
 )
 (assert_abi
   (witx
-    (typename $a (flags
-      $f0 $f1 $f2 $f3 $f4 $f5 $f6 $f7
-      $f8 $f9 $f10 $f11 $f12 $f13 $f14 $f15
-      $f16 $f17 $f18 $f19 $f20 $f21 $f22 $f23
-      $f24 $f25 $f26 $f27 $f28 $f29 $f30 $f31
-      $f32
-    ))
-    (module $x (export "f" (func (param $a $a) (result $b $a))))
+    (module $x
+      (typename $a (flags
+        $f0 $f1 $f2 $f3 $f4 $f5 $f6 $f7
+        $f8 $f9 $f10 $f11 $f12 $f13 $f14 $f15
+        $f16 $f17 $f18 $f19 $f20 $f21 $f22 $f23
+        $f24 $f25 $f26 $f27 $f28 $f29 $f30 $f31
+        $f32
+      ))
+      (export "f" (func (param $a $a) (result $b $a)))
+    )
   )
   (wasm (param i64) (result i64))
 )
 (assert_abi
   (witx
-    (typename $a (flags $a $b))
-    (module $x (export "f" (func
-      (param $a (list $a))
-      (result $b (list $a))
-    )))
+    (module $x
+      (typename $a (flags $a $b))
+      (export "f" (func
+        (param $a (list $a))
+        (result $b (list $a))
+      ))
+    )
   )
   (wasm (param i32 i32 i32))
   (declared_import

--- a/tools/witx/tests/witxt/abi.witxt
+++ b/tools/witx/tests/witxt/abi.witxt
@@ -100,8 +100,10 @@
 ;; flags parameter
 (assert_abi
   (witx
-    (typename $a (flags $x $y))
-    (module $x (@interface func (export "f") (param $p $a)))
+    (module $x
+      (typename $a (flags $x $y))
+      (@interface func (export "f") (param $p $a))
+    )
   )
   (wasm (param i32))
   (declared_import get-arg0 i32.from_bitflags arg0 call.wasm return)
@@ -109,8 +111,10 @@
 )
 (assert_abi
   (witx
-    (typename $a (flags (@witx repr u64) $x $y))
-    (module $x (@interface func (export "f") (param $p $a)))
+    (module $x
+      (typename $a (flags (@witx repr u64) $x $y))
+      (@interface func (export "f") (param $p $a))
+    )
   )
   (wasm (param i64))
   (declared_import get-arg0 i64.from_bitflags arg0 call.wasm return)
@@ -118,8 +122,10 @@
 )
 (assert_abi
   (witx
-    (typename $a (record (field $x bool)))
-    (module $x (@interface func (export "f") (param $p $a)))
+    (module $x
+      (typename $a (record (field $x bool)))
+      (@interface func (export "f") (param $p $a))
+    )
   )
   (wasm (param i32))
   (declared_import get-arg0 i32.from_bitflags arg0 call.wasm return)
@@ -128,8 +134,10 @@
 ;; struct parameter
 (assert_abi
   (witx
-    (typename $a (record (field $x u8)))
-    (module $x (@interface func (export "f") (param $p $a)))
+    (module $x
+      (typename $a (record (field $x u8)))
+      (@interface func (export "f") (param $p $a))
+    )
   )
   (wasm (param i32))
   (declared_import get-arg0 addr-of arg0 call.wasm return)
@@ -145,9 +153,11 @@
 ;; handle parameter
 (assert_abi
   (witx
-    (resource $a)
-    (typename $a (handle $a))
-    (module $x (@interface func (export "f") (param $p $a)))
+    (module $x
+      (resource $a)
+      (typename $a (handle $a))
+      (@interface func (export "f") (param $p $a))
+    )
   )
   (wasm (param i32))
   (declared_import get-arg0 i32.from_borrowed_handle arg0 call.wasm return)
@@ -157,7 +167,8 @@
 ;; list parameter
 (assert_abi
   (witx
-    (module $x (@interface func (export "f") (param $p (list u8))))
+    (module $x
+      (@interface func (export "f") (param $p (list u8))))
   )
   (wasm (param i32 i32))
   (declared_import get-arg0 list.canon_lower arg0 call.wasm return)
@@ -172,8 +183,10 @@
 ;; variant parameter -- some not allowed at this time
 (assert_abi
   (witx
-    (typename $a (enum $b))
-    (module $x (@interface func (export "f") (param $p $a)))
+    (module $x
+      (typename $a (enum $b))
+      (@interface func (export "f") (param $p $a))
+    )
   )
   (wasm (param i32))
   (declared_import
@@ -194,8 +207,10 @@
 )
 (assert_abi
   (witx
-    (typename $a (union f32))
-    (module $x (@interface func (export "f") (param $p $a)))
+    (module $x
+      (typename $a (union f32))
+      (@interface func (export "f") (param $p $a))
+    )
   )
   (wasm (param i32))
   (declared_import get-arg0 addr-of arg0 call.wasm return)
@@ -306,8 +321,10 @@
 ;; flags ret0 return
 (assert_abi
   (witx
-    (typename $a (flags $x $y))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $a (flags $x $y))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   (wasm (result i32))
   (declared_import call.wasm bitflags.from_i32 ret0 return)
@@ -315,8 +332,10 @@
 )
 (assert_abi
   (witx
-    (typename $a (flags (@witx repr u64) $x $y))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $a (flags (@witx repr u64) $x $y))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   (wasm (result i64))
   (declared_import call.wasm bitflags.from_i64 ret0 return)
@@ -326,9 +345,11 @@
 ;; handle ret0 return
 (assert_abi
   (witx
-    (resource $a)
-    (typename $a (handle $a))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (resource $a)
+      (typename $a (handle $a))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   (wasm (result i32))
   (declared_import call.wasm handle.owned_from_i32 ret0 return)
@@ -338,8 +359,10 @@
 ;; struct return -- not supported
 (assert_invalid
   (witx
-    (typename $a (record (field $x u8)))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $a (record (field $x u8)))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   "ABI error: invalid return type"
 )
@@ -355,30 +378,38 @@
 ;; variant return -- only some allowed
 (assert_invalid
   (witx
-    (typename $a (enum $b))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $a (enum $b))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   "ABI error: invalid return type"
 )
 (assert_invalid
   (witx
-    (typename $a (union s32 f32))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $a (union s32 f32))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   "ABI error: invalid return type"
 )
 (assert_invalid
   (witx
-    (typename $a (expected (error f32)))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $a (expected (error f32)))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   "ABI error: only named types are allowed in results"
 )
 (assert_invalid
   (witx
-    (typename $errno (enum $success $bad))
-    (typename $a (expected f32 (error $errno)))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $errno (enum $success $bad))
+      (typename $a (expected f32 (error $errno)))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   "ABI error: only named types are allowed in results"
 )
@@ -386,9 +417,11 @@
 ;; Result<(), $errno>
 (assert_abi
   (witx
-    (typename $errno (enum $success $bad))
-    (typename $a (expected (error $errno)))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $errno (enum $success $bad))
+      (typename $a (expected (error $errno)))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   (wasm (result i32))
 
@@ -438,10 +471,12 @@
 ;; Result<$ty, $errno>
 (assert_abi
   (witx
-    (typename $errno (enum $success $bad))
-    (typename $size u32)
-    (typename $a (expected $size (error $errno)))
-    (module $x (@interface func (export "f") (result $p $a)))
+    (module $x
+      (typename $errno (enum $success $bad))
+      (typename $size u32)
+      (typename $a (expected $size (error $errno)))
+      (@interface func (export "f") (result $p $a))
+    )
   )
   (wasm (param i32) (result i32))
 
@@ -496,11 +531,13 @@
 ;; Result<($a, $b), $errno>
 (assert_abi
   (witx
-    (typename $errno (enum $success $bad))
-    (typename $size u32)
-    (typename $other (record (field $a $size)))
-    (module $x (@interface func (export "f")
-      (result $p (expected (tuple $size $other) (error $errno)))))
+    (module $x
+      (typename $errno (enum $success $bad))
+      (typename $size u32)
+      (typename $other (record (field $a $size)))
+      (@interface func (export "f")
+        (result $p (expected (tuple $size $other) (error $errno))))
+    )
   )
   (wasm (param i32 i32) (result i32))
 

--- a/tools/witx/tests/witxt/anonymous.witxt
+++ b/tools/witx/tests/witxt/anonymous.witxt
@@ -3,55 +3,55 @@
 
 (assert_invalid
   (witx
-    (typename $a (@witx pointer (record (field $b u8))))
+    (module $x (typename $a (@witx pointer (record (field $b u8)))))
   )
   "Anonymous structured types")
 
 (assert_invalid
   (witx
-    (typename $a (@witx pointer (union)))
+    (module $x (typename $a (@witx pointer (union))))
   )
   "Anonymous structured types")
 
 (assert_invalid
   (witx
-    (typename $a (@witx pointer (enum $b)))
+    (module $x (typename $a (@witx pointer (enum $b))))
   )
   "Anonymous structured types")
 
 (assert_invalid
   (witx
-    (typename $a (@witx pointer (flags $b)))
+    (module $x (typename $a (@witx pointer (flags $b))))
   )
   "Anonymous structured types")
 
 (assert_invalid
-  (witx
+  (witx (module $x
     (resource $x)
     (typename $a (@witx pointer (handle $x)))
-  )
+  ))
   "Anonymous structured types")
 
 (assert_invalid
   (witx
-    (typename $a (record (field $b (record (field $c u8)))))
+    (module $x (typename $a (record (field $b (record (field $c u8))))))
   )
   "Anonymous structured types")
 
 (assert_invalid
-  (witx
+  (witx (module $x
     (typename $tag (enum $c))
     (typename $a (record (field $b (union))))
-  )
+  ))
   "Anonymous structured types")
 
 
 ;; pointers don't count for anonymous indirections
 (witx
-  (typename $a (@witx pointer u8)))
+  (module $x (typename $a (@witx pointer u8))))
 
 (witx
-  (typename $a (@witx pointer (@witx const_pointer u8))))
+  (module $x (typename $a (@witx pointer (@witx const_pointer u8)))))
 
 (witx
-  (typename $a (record (field $b (@witx pointer u8)))))
+  (module $x (typename $a (record (field $b (@witx pointer u8))))))

--- a/tools/witx/tests/witxt/multimodule.witxt
+++ b/tools/witx/tests/witxt/multimodule.witxt
@@ -1,20 +1,20 @@
 ;; B uses A, and C uses A.
-(witx $b (load "multimodule/type_b.witx"))
-(witx $c (load "multimodule/type_c.witx"))
+(witx (load "multimodule/type_b.witx"))
+(witx (load "multimodule/type_c.witx"))
 
-(witx $reference (module $x
+(witx (module $reference
   (typename $a u32)
   (typename $b (record (field $member_a $a)))
   (typename $c (record (field $first_a $a) (field $second_a $a)))
 ))
 
-(assert_eq $reference "a" $b "a")
-(assert_eq $reference "a" $c "a")
-(assert_eq $reference "b" $b "b")
-(assert_eq $reference "c" $c "c")
+(assert_eq $reference "a" $type_b "a")
+(assert_eq $reference "a" $type_c "a")
+(assert_eq $reference "b" $type_b "b")
+(assert_eq $reference "c" $type_c "c")
 
 (assert_invalid
   (witx (load "multimodule/redefine_a.witx"))
   "Redefinition of name `a`")
 
-(witx $c (load "multimodule/use_of_structured.witx"))
+(witx (load "multimodule/use_of_structured.witx"))

--- a/tools/witx/tests/witxt/multimodule.witxt
+++ b/tools/witx/tests/witxt/multimodule.witxt
@@ -2,11 +2,11 @@
 (witx $b (load "multimodule/type_b.witx"))
 (witx $c (load "multimodule/type_c.witx"))
 
-(witx $reference
+(witx $reference (module $x
   (typename $a u32)
   (typename $b (record (field $member_a $a)))
   (typename $c (record (field $first_a $a) (field $second_a $a)))
-)
+))
 
 (assert_eq $reference "a" $b "a")
 (assert_eq $reference "a" $c "a")

--- a/tools/witx/tests/witxt/multimodule/redefine_a.witx
+++ b/tools/witx/tests/witxt/multimodule/redefine_a.witx
@@ -1,2 +1,4 @@
-(use $a from $type_a)
-(module $redefine_a (typename $a u8))
+(module $redefine_a
+  (use $a from $type_a)
+  (typename $a u8)
+)

--- a/tools/witx/tests/witxt/multimodule/redefine_a.witx
+++ b/tools/witx/tests/witxt/multimodule/redefine_a.witx
@@ -1,2 +1,2 @@
 (use $a from $type_a)
-(typename $a u8)
+(module $x (typename $a u8))

--- a/tools/witx/tests/witxt/multimodule/redefine_a.witx
+++ b/tools/witx/tests/witxt/multimodule/redefine_a.witx
@@ -1,2 +1,2 @@
 (use $a from $type_a)
-(module $x (typename $a u8))
+(module $redefine_a (typename $a u8))

--- a/tools/witx/tests/witxt/multimodule/structured.witx
+++ b/tools/witx/tests/witxt/multimodule/structured.witx
@@ -1,4 +1,4 @@
-(module $x
+(module $structured
   (typename $a u32)
   (typename $foo (tuple $a))
 )

--- a/tools/witx/tests/witxt/multimodule/structured.witx
+++ b/tools/witx/tests/witxt/multimodule/structured.witx
@@ -1,2 +1,4 @@
-(typename $a u32)
-(typename $foo (tuple $a))
+(module $x
+  (typename $a u32)
+  (typename $foo (tuple $a))
+)

--- a/tools/witx/tests/witxt/multimodule/type_a.witx
+++ b/tools/witx/tests/witxt/multimodule/type_a.witx
@@ -1,1 +1,1 @@
-(typename $a u32)
+(module $x (typename $a u32))

--- a/tools/witx/tests/witxt/multimodule/type_a.witx
+++ b/tools/witx/tests/witxt/multimodule/type_a.witx
@@ -1,1 +1,1 @@
-(module $x (typename $a u32))
+(module $type_a (typename $a u32))

--- a/tools/witx/tests/witxt/multimodule/type_b.witx
+++ b/tools/witx/tests/witxt/multimodule/type_b.witx
@@ -1,2 +1,2 @@
 (use $a from $type_a)
-(typename $b (record (field $member_a $a)))
+(module $x (typename $b (record (field $member_a $a))))

--- a/tools/witx/tests/witxt/multimodule/type_b.witx
+++ b/tools/witx/tests/witxt/multimodule/type_b.witx
@@ -1,2 +1,4 @@
-(use $a from $type_a)
-(module $type_b (typename $b (record (field $member_a $a))))
+(module $type_b
+  (use $a from $type_a)
+  (typename $b (record (field $member_a $a)))
+)

--- a/tools/witx/tests/witxt/multimodule/type_b.witx
+++ b/tools/witx/tests/witxt/multimodule/type_b.witx
@@ -1,2 +1,2 @@
 (use $a from $type_a)
-(module $x (typename $b (record (field $member_a $a))))
+(module $type_b (typename $b (record (field $member_a $a))))

--- a/tools/witx/tests/witxt/multimodule/type_c.witx
+++ b/tools/witx/tests/witxt/multimodule/type_c.witx
@@ -1,2 +1,2 @@
 (use $a from $type_a)
-(module $x (typename $c (record (field $first_a $a) (field $second_a $a))))
+(module $type_c (typename $c (record (field $first_a $a) (field $second_a $a))))

--- a/tools/witx/tests/witxt/multimodule/type_c.witx
+++ b/tools/witx/tests/witxt/multimodule/type_c.witx
@@ -1,2 +1,4 @@
-(use $a from $type_a)
-(module $type_c (typename $c (record (field $first_a $a) (field $second_a $a))))
+(module $type_c
+  (use $a from $type_a)
+  (typename $c (record (field $first_a $a) (field $second_a $a)))
+)

--- a/tools/witx/tests/witxt/multimodule/type_c.witx
+++ b/tools/witx/tests/witxt/multimodule/type_c.witx
@@ -1,2 +1,2 @@
 (use $a from $type_a)
-(typename $c (record (field $first_a $a) (field $second_a $a)))
+(module $x (typename $c (record (field $first_a $a) (field $second_a $a))))

--- a/tools/witx/tests/witxt/multimodule/use_of_structured.witx
+++ b/tools/witx/tests/witxt/multimodule/use_of_structured.witx
@@ -1,1 +1,3 @@
-(use $foo from $structured)
+(module $use_of_structured
+  (use $foo from $structured)
+)

--- a/tools/witx/tests/witxt/resources.witxt
+++ b/tools/witx/tests/witxt/resources.witxt
@@ -1,37 +1,37 @@
 (assert_invalid
-  (witx (typename $x (handle $y)))
+  (witx (module $b (typename $x (handle $y))))
   "Unknown name `y`")
 
 (assert_invalid
-  (witx
+  (witx (module $b
     (typename $y u32)
-    (typename $x (handle $y)))
+    (typename $x (handle $y))))
   "Unknown name `y`")
 
 (assert_invalid
-  (witx
+  (witx (module $b
     (resource $x)
-    (resource $x))
+    (resource $x)))
   "Redefinition of name `x`")
 
-(witx
+(witx (module $b
   (resource $x)
-  (typename $x (handle $x)))
+  (typename $x (handle $x))))
 
-(witx $a
+(witx $a (module $b
   (resource $x)
   (typename $x (handle $x))
   (typename $y (handle $x))
-)
+))
 
 (assert_eq $a "x" $a "y")
 
-(witx $a
+(witx $a (module $b
   (resource $x)
   (resource $y)
   (typename $x (handle $x))
   (typename $y (handle $y))
-)
+))
 
 (assert_ne $a "x" $a "y")
 

--- a/tools/witx/tests/witxt/resources.witxt
+++ b/tools/witx/tests/witxt/resources.witxt
@@ -18,7 +18,7 @@
   (resource $x)
   (typename $x (handle $x))))
 
-(witx $a (module $b
+(witx (module $a
   (resource $x)
   (typename $x (handle $x))
   (typename $y (handle $x))
@@ -26,7 +26,7 @@
 
 (assert_eq $a "x" $a "y")
 
-(witx $a (module $b
+(witx (module $a
   (resource $x)
   (resource $y)
   (typename $x (handle $x))
@@ -35,7 +35,7 @@
 
 (assert_ne $a "x" $a "y")
 
-(witx $a (load "resources/multi.witx"))
+(witx (load "resources/multi.witx"))
 
-(assert_eq $a "x1" $a "x2")
-(assert_ne $a "y1" $a "y2")
+(assert_eq $multi "x1" $multi "x2")
+(assert_ne $multi "y1" $multi "y2")

--- a/tools/witx/tests/witxt/resources/multi.witx
+++ b/tools/witx/tests/witxt/resources/multi.witx
@@ -1,6 +1,6 @@
-(use ($x as $other_x) ($y as $other_y) from $other)
-
 (module $multi
+  (use ($x as $other_x) ($y as $other_y) from $other)
+
   ;; this resource named `y` shouldn't be the same as another resource named `y`
   ;; defined elsewhere.
   (resource $y)

--- a/tools/witx/tests/witxt/resources/multi.witx
+++ b/tools/witx/tests/witxt/resources/multi.witx
@@ -1,6 +1,6 @@
 (use ($x as $other_x) ($y as $other_y) from $other)
 
-(module $b
+(module $multi
   ;; this resource named `y` shouldn't be the same as another resource named `y`
   ;; defined elsewhere.
   (resource $y)

--- a/tools/witx/tests/witxt/resources/multi.witx
+++ b/tools/witx/tests/witxt/resources/multi.witx
@@ -1,11 +1,13 @@
 (use ($x as $other_x) ($y as $other_y) from $other)
 
-;; this resource named `y` shouldn't be the same as another resource named `y`
-;; defined elsewhere.
-(resource $y)
+(module $b
+  ;; this resource named `y` shouldn't be the same as another resource named `y`
+  ;; defined elsewhere.
+  (resource $y)
 
-(typename $x1 (handle $other_x))
-(typename $x2 (handle $other_x))
+  (typename $x1 (handle $other_x))
+  (typename $x2 (handle $other_x))
 
-(typename $y1 (handle $other_y))
-(typename $y2 (handle $y))
+  (typename $y1 (handle $other_y))
+  (typename $y2 (handle $y))
+)

--- a/tools/witx/tests/witxt/resources/other.witx
+++ b/tools/witx/tests/witxt/resources/other.witx
@@ -1,2 +1,4 @@
-(resource $x)
-(resource $y)
+(module $b
+  (resource $x)
+  (resource $y)
+)

--- a/tools/witx/tests/witxt/resources/other.witx
+++ b/tools/witx/tests/witxt/resources/other.witx
@@ -1,4 +1,4 @@
-(module $b
+(module $other
   (resource $x)
   (resource $y)
 )

--- a/tools/witx/tests/witxt/shorthand.witxt
+++ b/tools/witx/tests/witxt/shorthand.witxt
@@ -1,65 +1,65 @@
-(witx $a
-  (module $b (typename $a bool)))
-(witx $b
+(witx
+  (module $a (typename $a bool)))
+(witx
   (module $b (typename $a (variant (case $false) (case $true)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (expected (error)))))
-(witx $b
+(witx
+  (module $a (typename $a (expected (error)))))
+(witx
   (module $b (typename $a (variant (case $ok) (case $err)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (expected (error u32)))))
-(witx $b
+(witx
+  (module $a (typename $a (expected (error u32)))))
+(witx
   (module $b (typename $a (variant (case $ok) (case $err u32)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (expected u32 (error)))))
-(witx $b
+(witx
+  (module $a (typename $a (expected u32 (error)))))
+(witx
   (module $b (typename $a (variant (case $ok u32) (case $err)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (expected u32 (error u64)))))
-(witx $b
+(witx
+  (module $a (typename $a (expected u32 (error u64)))))
+(witx
   (module $b (typename $a (variant (case $ok u32) (case $err u64)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (flags $a $b))))
-(witx $b
+(witx
+  (module $a (typename $a (flags $a $b))))
+(witx
   (module $b (typename $a (record (field $a bool) (field $b bool)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (enum $a $b))))
-(witx $b
+(witx
+  (module $a (typename $a (enum $a $b))))
+(witx
   (module $b (typename $a (variant (case $a) (case $b)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a string)))
-(witx $b
+(witx
+  (module $a (typename $a string)))
+(witx
   (module $b (typename $a (list char))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (tuple u32 u64))))
-(witx $b
+(witx
+  (module $a (typename $a (tuple u32 u64))))
+(witx
   (module $b (typename $a (record (field $0 u32) (field $1 u64)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (union u32 u64))))
-(witx $b
+(witx
+  (module $a (typename $a (union u32 u64))))
+(witx
   (module $b (typename $a (variant (case $0 u32) (case $1 u64)))))
 (assert_eq $a "a" $b "a")
 
-(witx $a
-  (module $b (typename $a (option u32))))
-(witx $b
+(witx
+  (module $a (typename $a (option u32))))
+(witx
   (module $b (typename $a (variant (case $none) (case $some u32)))))
 (assert_eq $a "a" $b "a")

--- a/tools/witx/tests/witxt/shorthand.witxt
+++ b/tools/witx/tests/witxt/shorthand.witxt
@@ -1,65 +1,65 @@
 (witx $a
-  (typename $a bool))
+  (module $b (typename $a bool)))
 (witx $b
-  (typename $a (variant (case $false) (case $true))))
+  (module $b (typename $a (variant (case $false) (case $true)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (expected (error))))
+  (module $b (typename $a (expected (error)))))
 (witx $b
-  (typename $a (variant (case $ok) (case $err))))
+  (module $b (typename $a (variant (case $ok) (case $err)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (expected (error u32))))
+  (module $b (typename $a (expected (error u32)))))
 (witx $b
-  (typename $a (variant (case $ok) (case $err u32))))
+  (module $b (typename $a (variant (case $ok) (case $err u32)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (expected u32 (error))))
+  (module $b (typename $a (expected u32 (error)))))
 (witx $b
-  (typename $a (variant (case $ok u32) (case $err))))
+  (module $b (typename $a (variant (case $ok u32) (case $err)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (expected u32 (error u64))))
+  (module $b (typename $a (expected u32 (error u64)))))
 (witx $b
-  (typename $a (variant (case $ok u32) (case $err u64))))
+  (module $b (typename $a (variant (case $ok u32) (case $err u64)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (flags $a $b)))
+  (module $b (typename $a (flags $a $b))))
 (witx $b
-  (typename $a (record (field $a bool) (field $b bool))))
+  (module $b (typename $a (record (field $a bool) (field $b bool)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (enum $a $b)))
+  (module $b (typename $a (enum $a $b))))
 (witx $b
-  (typename $a (variant (case $a) (case $b))))
+  (module $b (typename $a (variant (case $a) (case $b)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a string))
+  (module $b (typename $a string)))
 (witx $b
-  (typename $a (list char)))
+  (module $b (typename $a (list char))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (tuple u32 u64)))
+  (module $b (typename $a (tuple u32 u64))))
 (witx $b
-  (typename $a (record (field $0 u32) (field $1 u64))))
+  (module $b (typename $a (record (field $0 u32) (field $1 u64)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (union u32 u64)))
+  (module $b (typename $a (union u32 u64))))
 (witx $b
-  (typename $a (variant (case $0 u32) (case $1 u64))))
+  (module $b (typename $a (variant (case $0 u32) (case $1 u64)))))
 (assert_eq $a "a" $b "a")
 
 (witx $a
-  (typename $a (option u32)))
+  (module $b (typename $a (option u32))))
 (witx $b
-  (typename $a (variant (case $none) (case $some u32))))
+  (module $b (typename $a (variant (case $none) (case $some u32)))))
 (assert_eq $a "a" $b "a")

--- a/tools/witx/tests/witxt/simple.witxt
+++ b/tools/witx/tests/witxt/simple.witxt
@@ -1,4 +1,6 @@
-(witx)
+(witx
+  (module $a)
+)
 
 (witx
   (module $a (typename $x u32))

--- a/tools/witx/tests/witxt/simple.witxt
+++ b/tools/witx/tests/witxt/simple.witxt
@@ -1,12 +1,14 @@
 (witx)
 
 (witx
-  (typename $x u32)
+  (module $a (typename $x u32))
 )
 
 (assert_invalid
   (witx
-    (typename $x u32)
-    (typename $x u32)
+    (module $a
+      (typename $x u32)
+      (typename $x u32)
+    )
   )
   "Redefinition of name `x`")

--- a/tools/witx/tests/witxt/snapshot_0.witx
+++ b/tools/witx/tests/witxt/snapshot_0.witx
@@ -1,0 +1,1 @@
+(witx (load "../../../../phases/old/snapshot_0/witx/wasi_unstable.witx"))

--- a/tools/witx/tests/witxt/snapshot_preview1.witx
+++ b/tools/witx/tests/witxt/snapshot_preview1.witx
@@ -1,0 +1,1 @@
+(witx (load "../../../../phases/snapshot/witx/wasi_snapshot_preview1.witx"))

--- a/tools/witx/tests/witxt/union.witxt
+++ b/tools/witx/tests/witxt/union.witxt
@@ -90,15 +90,15 @@
   "Union expected 2 variants, found 1"
 )
 
-(witx $d1
-  (module $a
+(witx
+  (module $d1
     (typename $tag (enum $a $b))
     (typename $u (union (@witx tag $tag) u8 u16))
   )
 )
 
-(witx $d2
-  (module $a
+(witx
+  (module $d2
     (typename $tag (enum $a $b))
     (typename $u (variant (@witx tag $tag) (case $b u16) (case $a u8)))
   )
@@ -109,8 +109,8 @@
 (assert_eq $d2 "u" $d1 "u")
 
 ;; Tag order doesnt matter for validation, but does for equality
-(witx $d3
-  (module $a
+(witx
+  (module $d3
     (typename $tag (enum $b $a))
     (typename $u (union (@witx tag $tag) u16 u8))
   )

--- a/tools/witx/tests/witxt/union.witxt
+++ b/tools/witx/tests/witxt/union.witxt
@@ -1,87 +1,107 @@
 
 (witx
-  (typename $u (union u8))
+  (module $a (typename $u (union u8)))
 )
 (witx
-  (typename $tag (enum (@witx tag u8) $c))
-  (typename $u (union (@witx tag $tag) u8))
-)
-
-(witx
-  (typename $tag (enum $a $b))
-  (typename $u (variant (@witx tag $tag) (case $a) (case $b u16)))
+  (module $a
+    (typename $tag (enum (@witx tag u8) $c))
+    (typename $u (union (@witx tag $tag) u8))
+  )
 )
 
 (witx
-  (typename $tag (enum $a $b))
-  (typename $u (variant (@witx tag $tag) (case $a) (case $b)))
+  (module $a
+    (typename $tag (enum $a $b))
+    (typename $u (variant (@witx tag $tag) (case $a) (case $b u16)))
+  )
+)
+
+(witx
+  (module $a
+    (typename $tag (enum $a $b))
+    (typename $u (variant (@witx tag $tag) (case $a) (case $b)))
+  )
 )
 
 
 (witx
- (typename $u
-  (union
-   u8
-   u16
-   u32
-   u64
-   s8
-   s16
-   s32
-   s64
-   f32
-   f64
-   (@witx usize)
-   (@witx char8)
+ (module $a
+  (typename $u
+   (union
+    u8
+    u16
+    u32
+    u64
+    s8
+    s16
+    s32
+    s64
+    f32
+    f64
+    (@witx usize)
+    (@witx char8)
+   )
   )
  )
 )
 
 (assert_invalid
-  (witx (typename $u (union (@witx tag $tag) u8 u16)))
+  (witx (module $a (typename $u (union (@witx tag $tag) u8 u16))))
   "Unknown name `tag`"
 )
 
 (assert_invalid
   (witx
-    (typename $tag string)
-    (typename $u (union (@witx tag $tag) u8 u16))
+    (module $a
+      (typename $tag string)
+      (typename $u (union (@witx tag $tag) u8 u16))
+    )
   )
   "Wrong kind of name `tag`: expected enum or builtin, got list"
 )
 
 (assert_invalid
   (witx
-    (typename $tag (enum $c))
-    (typename $u (variant (@witx tag $tag) (case $b u8)))
+    (module $a
+      (typename $tag (enum $c))
+      (typename $u (variant (@witx tag $tag) (case $b u8)))
+    )
   )
   "Invalid union field `b`: does not correspond to variant in tag `tag`"
 )
 
 (assert_invalid
   (witx
-    (typename $tag (enum $c))
-    (typename $u (union (@witx tag $tag) f32 u8))
+    (module $a
+      (typename $tag (enum $c))
+      (typename $u (union (@witx tag $tag) f32 u8))
+    )
   )
   "Union expected 1 variants, found 2"
 )
 
 (assert_invalid
   (witx
-    (typename $tag (enum $c $d))
-    (typename $u (union (@witx tag $tag) f32))
+    (module $a
+      (typename $tag (enum $c $d))
+      (typename $u (union (@witx tag $tag) f32))
+    )
   )
   "Union expected 2 variants, found 1"
 )
 
 (witx $d1
-  (typename $tag (enum $a $b))
-  (typename $u (union (@witx tag $tag) u8 u16))
+  (module $a
+    (typename $tag (enum $a $b))
+    (typename $u (union (@witx tag $tag) u8 u16))
+  )
 )
 
 (witx $d2
-  (typename $tag (enum $a $b))
-  (typename $u (variant (@witx tag $tag) (case $b u16) (case $a u8)))
+  (module $a
+    (typename $tag (enum $a $b))
+    (typename $u (variant (@witx tag $tag) (case $b u16) (case $a u8)))
+  )
 )
 
 ;; These two unions should be represented the same:
@@ -90,8 +110,10 @@
 
 ;; Tag order doesnt matter for validation, but does for equality
 (witx $d3
-  (typename $tag (enum $b $a))
-  (typename $u (union (@witx tag $tag) u16 u8))
+  (module $a
+    (typename $tag (enum $b $a))
+    (typename $u (union (@witx tag $tag) u16 u8))
+  )
 )
 
 (assert_ne $d3 "u" $d1 "u")

--- a/tools/witx/tests/witxt/wasi.witxt
+++ b/tools/witx/tests/witxt/wasi.witxt
@@ -1,13 +1,9 @@
 ;; Ensure that all current witx definitions in this repository load, parse,
 ;; roundtrip, and are documentable.
 
-(witx (load "../../../../phases/old/snapshot_0/witx/wasi_unstable.witx"))
-(witx (load "../../../../phases/snapshot/witx/wasi_snapshot_preview1.witx"))
-
 (witx (load "../../../../phases/ephemeral/witx/wasi_ephemeral_args.witx"))
 (witx (load "../../../../phases/ephemeral/witx/wasi_ephemeral_clock.witx"))
 (witx (load "../../../../phases/ephemeral/witx/wasi_ephemeral_environ.witx"))
-(witx (load "../../../../phases/ephemeral/witx/wasi_ephemeral_fd.witx"))
 (witx (load "../../../../phases/ephemeral/witx/wasi_ephemeral_fd.witx"))
 (witx (load "../../../../phases/ephemeral/witx/wasi_ephemeral_path.witx"))
 (witx (load "../../../../phases/ephemeral/witx/wasi_ephemeral_poll.witx"))


### PR DESCRIPTION
Resources in particular are conceptually part of modules. Typenames and consts are less clear, but since one can `use` them from other modules, it makes sense to think of them also as being "part of the module".
